### PR TITLE
refactor/remove unnecessary buildToolsVersion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
     compileSdk 33
-    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.futureplatforms.pizzamenu"


### PR DESCRIPTION
It is now obsolete with the migration to a newer version of gradle. Also the version is wrong, given the targetSdk and compileSdk versions.